### PR TITLE
Exit code error handling

### DIFF
--- a/longoverdue.py
+++ b/longoverdue.py
@@ -179,22 +179,28 @@ def restart():
 
     command = []
     if euid == 0 and services:
-        command = ["systemctl", "daemon-reload"]
-        print(" ".join(command))
-        subprocess.run(command, check=True)
+        try:
+            command = ["systemctl", "daemon-reload"]
+            print(" ".join(command))
+            subprocess.run(command, check=True)
 
-        command = ["systemctl", "restart"] + list(services)
-        print(" ".join(command))
-        subprocess.run(command, check=True)
+            command = ["systemctl", "restart"] + list(services)
+            print(" ".join(command))
+            subprocess.run(command, check=True)
+        except subprocess.CalledProcessError:
+            sys.exit(1)
 
     elif euid != 0 and userservices:
-        command = ["systemctl", "--user", "daemon-reload"]
-        print(" ".join(command))
-        subprocess.run(command, check=True)
+        try:
+            command = ["systemctl", "--user", "daemon-reload"]
+            print(" ".join(command))
+            subprocess.run(command, check=True)
 
-        command = ["systemctl", "--user", "restart"] + list(userservices)
-        print(" ".join(command))
-        subprocess.run(command, check=True)
+            command = ["systemctl", "--user", "restart"] + list(userservices)
+            print(" ".join(command))
+            subprocess.run(command, check=True)
+        except subprocess.CalledProcessError:
+            sys.exit(1)
 
 @main.command()
 @click.argument("regex")


### PR DESCRIPTION
Handles following crashes.

- systemd exits non-zero
```
Traceback (most recent call last):
  File "/usr/bin/longoverdue", line 233, in <module>
    main()
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/usr/bin/longoverdue", line 189, in restart
    subprocess.run(command, check=True)
  File "/usr/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['systemctl', 'restart', 'php74-fpm.service']' returned non-zero exit status 1.
```